### PR TITLE
Cd deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,23 @@
 # Pipeline from https://www.eliostruyf.com/publishing-vscode-extensions-github-actions/
+
+# This GitHub Actions workflow automatically publishes the VSCode extension to the Visual Studio Code Marketplace upon a new release being published. 
+# It checks out the code, sets up a Node.js environment, installs dependencies, installs the vsce tool. 
+# Then publishes the extension using a Personal Access Token (PAT) stored in the repository's secrets.
+
 name: Release
 on:
   release:
     types:
-      - published
-  workflow_dispatch:
+      - published # Triggered when a release is published. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  workflow_dispatch: # Allows manual triggering of the workflow.
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2 # Checks out the repository code.
+      - uses: actions/setup-node@v1 # Sets up Node.js environment.
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
@@ -20,8 +25,10 @@ jobs:
       - name: Install the dependencies
         run: npm i
 
-      - name: Install vsce
+      - name: Install vsce # Installs the vsce tool globally. https://code.visualstudio.com/api/working-with-extensions/publishing-extension
         run: npm i -g vsce
 
       - name: Publish
-        run: vsce publish -p ${{ secrets.VSCE_PAT }}
+        # run: vsce publish -p ${{ secrets.VSCE_PAT }}
+        run: echo "Run publish here!"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# Pipeline from https://www.eliostruyf.com/publishing-vscode-extensions-github-actions/
+name: Release
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install the dependencies
+        run: npm i
+
+      - name: Install vsce
+        run: npm i -g vsce
+
+      - name: Publish
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Pipeline from https://www.eliostruyf.com/publishing-vscode-extensions-github-actions/
 
-# This GitHub Actions workflow automatically publishes the VSCode extension to the Visual Studio Code Marketplace upon a new release being published. 
-# It checks out the code, sets up a Node.js environment, installs dependencies, installs the vsce tool. 
+# This GitHub Actions workflow automatically publishes the VSCode extension to the Visual Studio Code Marketplace upon a new release being published.
+# It checks out the code, sets up a Node.js environment, installs dependencies, installs the vsce tool.
 # Then publishes the extension using a Personal Access Token (PAT) stored in the repository's secrets.
 
 name: Release
@@ -9,6 +9,7 @@ on:
   release:
     types:
       - published # Triggered when a release is published. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+
   workflow_dispatch: # Allows manual triggering of the workflow.
 
 jobs:
@@ -29,6 +30,4 @@ jobs:
         run: npm i -g vsce
 
       - name: Publish
-        # run: vsce publish -p ${{ secrets.VSCE_PAT }}
-        run: echo "Run publish here!"
-
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the "Conda Wingman" extension will be documented in this 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.0.0] - 2023-02
+## [1.0.0] - 2024-02
 - First official release out of preview!
 - Adding `Delete Env` functionality.
+- Added automated release process using GitHub Actions.
 
 ## [0.2.1] - 2023-03
 - Fixed bug that kept wingman status bar items open even when yaml was closed.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/DJSaunders1997/Conda-Wingman/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)]()
+[![Release](https://github.com/DJSaunders1997/Conda-Wingman/actions/workflows/release.yml/badge.svg)](https://github.com/DJSaunders1997/Conda-Wingman/actions/workflows/release.yml)
 
 ![Banner](images/Logo-Banner.png)
-
-
-
 
 [![Version](https://vsmarketplacebadges.dev/version-short/djsaunders1997.conda-wingman.png?style=for-the-badge&colorA=252525&colorB=#42AF29)](https://marketplace.visualstudio.com/items?itemName=djsaunders1997.conda-wingman)
 [![Downloads](https://vsmarketplacebadges.dev/downloads-short/djsaunders1997.conda-wingman.png?style=for-the-badge&colorA=252525&colorB=#42AF29)](https://marketplace.visualstudio.com/items?itemName=djsaunders1997.conda-wingman)


### PR DESCRIPTION
Automating the release process with GitHub actions

I've tested that making a new release https://github.com/DJSaunders1997/Conda-Wingman/releases/tag/test_cd
Creates a new cd release https://github.com/DJSaunders1997/Conda-Wingman/actions/runs/8030491037

I have not tested that the VSCE deploy will successfully update the extension - but I can't see how to test without just trusting it so here we go.